### PR TITLE
Deal with overlap of tokens

### DIFF
--- a/lib/nexus_parser.rb
+++ b/lib/nexus_parser.rb
@@ -118,7 +118,7 @@ class NexusParser
     end
   end
 
-end
+end # end NexusParser
 
 
 # constructs the NexusParser
@@ -259,7 +259,7 @@ class Builder
     @nf
   end
 
-end # end file
+end # end Builder
 
   # NexusParser::ParseError
   class ParseError < StandardError

--- a/lib/nexus_parser.rb
+++ b/lib/nexus_parser.rb
@@ -3,9 +3,6 @@
 # uses the PhyloTree parser/lexer engine by Krishna Dole which in turn was based on
 # Thomas Mailund's <mailund@birc.dk> 'newick-1.0.5' Python library
 
-# outstanding issues:
-## need to resolve Tokens Labels, ValuePair, IDs
-
 module NexusParser
 
   require File.expand_path(File.join(File.dirname(__FILE__), 'nexus_parser', 'tokens'))

--- a/lib/nexus_parser/lexer.rb
+++ b/lib/nexus_parser/lexer.rb
@@ -33,18 +33,8 @@ class NexusParser::Lexer
     if @next_token
       return @next_token
     else
-      # check for a match on the specified class first
       if match(token_class)
         return @next_token
-      else
-        # now check all the tokens for a match
-        NexusParser::Tokens.nexus_file_token_list.each {|t|
-          return @next_token if match(t)
-        }
-      end
-      # no match, either end of string or lex-error
-      if @input != ''
-        raise( NexusParser::ParseError, "Lex Error, unknown token at #{@input[0..10]}...", caller)
       else
         return nil
       end

--- a/lib/nexus_parser/parser.rb
+++ b/lib/nexus_parser/parser.rb
@@ -194,25 +194,22 @@ class NexusParser::Parser
         break
       else
         opts = {}
-
         name = ""
-        index = @lexer.pop(NexusParser::Tokens::Number).value.to_i
-        (name = @lexer.pop(NexusParser::Tokens::Label).value) if @lexer.peek(NexusParser::Tokens::Label) # not always given a letter
+
+        index = @lexer.pop(NexusParser::Tokens::PositiveInteger).value.to_i
+
+        (name = @lexer.pop(NexusParser::Tokens::CharacterLabel).value) if @lexer.peek(NexusParser::Tokens::CharacterLabel) # not always given a letter
 
         @lexer.pop(NexusParser::Tokens::BckSlash) if @lexer.peek(NexusParser::Tokens::BckSlash)
 
         if !@lexer.peek(NexusParser::Tokens::Comma) || !@lexer.peek(NexusParser::Tokens::SemiColon)
           i = 0
 
-          # Number matching is given priority over Label matching (see Tokens
-          # list) but both are parsed into strings, so we're really matching
-          # against the union of those two tokens here.
-          while @lexer.peek(NexusParser::Tokens::Number) || @lexer.peek(NexusParser::Tokens::Label)
-            if @lexer.peek(NexusParser::Tokens::Number)
-              opts.update({i.to_s => @lexer.pop(NexusParser::Tokens::Number).value.to_s})
-            elsif @lexer.peek(NexusParser::Tokens::Label)
-              opts.update({i.to_s => @lexer.pop(NexusParser::Tokens::Label).value})
-            end
+          while @lexer.peek(NexusParser::Tokens::CharacterLabel)
+            opts.update({
+              i.to_s => @lexer.pop(NexusParser::Tokens::CharacterLabel).value
+            })
+
             i += 1
           end
         end

--- a/lib/nexus_parser/parser.rb
+++ b/lib/nexus_parser/parser.rb
@@ -266,17 +266,21 @@ class NexusParser::Parser
         if @lexer.peek(NexusParser::Tokens::ValuePair)
           @vars.update(@lexer.pop(NexusParser::Tokens::ValuePair).value)
 
-        elsif @lexer.peek(NexusParser::Tokens::Label)
-          if @vars[:type] # we have the data for this row write it, and start a new one
-
-            @builder.add_note(@vars)
-            @vars = {}
-          else
-            @vars.update(:type => @lexer.pop(NexusParser::Tokens::Label).value)
-          end
         elsif @lexer.peek(NexusParser::Tokens::FileLbl)
           @lexer.pop(NexusParser::Tokens::FileLbl)
           @vars.update(:file => 'file') # we check for whether :file key is present and handle conditionally
+
+        else @lexer.peek(NexusParser::Tokens::Label)
+          # If we already have a :type set then the Label we just peeked starts a
+          # new row, so write the current one and then start a new one.
+          if @vars[:type]
+            @builder.add_note(@vars)
+
+            @vars = {}
+            @vars.update(:type => @lexer.pop(NexusParser::Tokens::Label).value)
+          else
+            @vars.update(:type => @lexer.pop(NexusParser::Tokens::Label).value)
+          end
         end
       end
     end

--- a/lib/nexus_parser/tokens.rb
+++ b/lib/nexus_parser/tokens.rb
@@ -78,7 +78,6 @@ module NexusParser::Tokens
     @regexp = Regexp.new(/\A\s*(\s*taxlabels\s*)\s*/i)
   end
 
-  # same as ID
   class Label < Token
     @regexp = Regexp.new('\A\s*((\'+[^\']+\'+)|(\"+[^\"]+\"+)|(\w[^,:(); \t\n]*|_)+)\s*') #  matches "foo and stuff", foo, 'stuff or foo', '''foo''', """bar""" BUT NOT ""foo" " # choking on 'Foo_stuff_things'
     def initialize(str)
@@ -235,16 +234,6 @@ module NexusParser::Tokens
     @regexp = Regexp.new('\A\s*(\/)\s*')
   end
 
-  # labels
-  class ID < Token
-    @regexp = Regexp.new('\A\s*((\'[^\']+\')|(\w[^,:(); \t\n]*|_)+)\s*')
-    def initialize(str)
-      str.strip!
-      str = str[1..-2] if str[0..0] == "'" # get rid of quote marks
-      @value = str
-    end
-  end
-
   class Colon < Token
     @regexp = Regexp.new('\A\s*(:)\s*')
   end
@@ -295,7 +284,7 @@ module NexusParser::Tokens
       NexusParser::Tokens::Format,
       NexusParser::Tokens::RespectCase,
       NexusParser::Tokens::Equals,
-      NexusParser::Tokens::ValuePair,  # this has bad overlap with Label and likely IDs (need to kill the latter, its a lesser Label)
+      NexusParser::Tokens::ValuePair,  # this has bad overlap with Label
       NexusParser::Tokens::CharStateLabels,
       NexusParser::Tokens::ChrsBlk,
       NexusParser::Tokens::Number, # partial overlap with Label
@@ -314,7 +303,6 @@ module NexusParser::Tokens
       NexusParser::Tokens::Label, # must be before RowVec
       NexusParser::Tokens::RowVec,
       NexusParser::Tokens::LinkLine,
-      NexusParser::Tokens::ID # need to trash this
     ]
   end
 

--- a/lib/nexus_parser/tokens.rb
+++ b/lib/nexus_parser/tokens.rb
@@ -260,18 +260,8 @@ module NexusParser::Tokens
     @regexp = Regexp.new('\A\s*(\,)\s*')
   end
 
-  class Number < Token
-    @regexp = Regexp.new('\A\s*(-?\d+(\.\d+)?([eE][+-]?\d+)?)\s*')
-    def initialize(str)
-      # a little oddness here, in some case we don't want to include the .0
-      # see issues with numbers as labels
-      if str =~ /\./
-        @value = str.to_f
-      else
-        @value = str.to_i
-      end
-
-    end
+  class PositiveInteger < Token
+    @regexp = Regexp.new('\A\s*(\d+)\s*')
   end
 
   # NexusParser::Tokens::NexusComment

--- a/lib/nexus_parser/tokens.rb
+++ b/lib/nexus_parser/tokens.rb
@@ -262,49 +262,4 @@ module NexusParser::Tokens
 
   # NexusParser::Tokens::NexusComment
 
-  # this list also defines priority, i.e. if tokens have overlap (which they shouldn't!!) then the earlier indexed token will match first
-  def self.nexus_file_token_list
-    [ NexusParser::Tokens::NexusStart,
-      NexusParser::Tokens::BeginBlk,
-      NexusParser::Tokens::EndBlk,
-      NexusParser::Tokens::AuthorsBlk,
-      NexusParser::Tokens::SetsBlk,
-      NexusParser::Tokens::MqCharModelsBlk,
-      NexusParser::Tokens::AssumptionsBlk,
-      NexusParser::Tokens::CodonsBlk,
-      NexusParser::Tokens::MesquiteBlk,
-      NexusParser::Tokens::TreesBlk,
-      NexusParser::Tokens::LabelsBlk,
-      NexusParser::Tokens::TaxaBlk,
-      NexusParser::Tokens::NotesBlk,
-      NexusParser::Tokens::Title,
-      NexusParser::Tokens::Taxlabels,
-      NexusParser::Tokens::Dimensions,
-      NexusParser::Tokens::FileLbl,
-      NexusParser::Tokens::Format,
-      NexusParser::Tokens::RespectCase,
-      NexusParser::Tokens::Equals,
-      NexusParser::Tokens::ValuePair,  # this has bad overlap with Label
-      NexusParser::Tokens::CharStateLabels,
-      NexusParser::Tokens::ChrsBlk,
-      NexusParser::Tokens::Number, # partial overlap with Label
-      NexusParser::Tokens::Matrix,
-      NexusParser::Tokens::SemiColon,
-      NexusParser::Tokens::MesquiteIDs,
-      NexusParser::Tokens::MesquiteBlockID,
-      NexusParser::Tokens::BlkEnd,
-      NexusParser::Tokens::Colon,
-      NexusParser::Tokens::BckSlash,
-      NexusParser::Tokens::Comma,
-      NexusParser::Tokens::LParen,
-      NexusParser::Tokens::RParen,
-      NexusParser::Tokens::LBracket,
-      NexusParser::Tokens::RBracket,
-      NexusParser::Tokens::Label, # must be before RowVec
-      NexusParser::Tokens::RowVec,
-      NexusParser::Tokens::LinkLine,
-    ]
-  end
-
 end
-

--- a/lib/nexus_parser/tokens.rb
+++ b/lib/nexus_parser/tokens.rb
@@ -1,6 +1,7 @@
 module NexusParser::Tokens
 
   ENDBLKSTR = '(end|endblock)'.freeze
+  QUOTEDLABEL = '(\'+[^\']+\'+)|(\"+[^\"]+\"+)'
 
   class Token
     # this allows access the the class attribute regexp, without using a class variable
@@ -78,14 +79,27 @@ module NexusParser::Tokens
     @regexp = Regexp.new(/\A\s*(\s*taxlabels\s*)\s*/i)
   end
 
-  class Label < Token
-    @regexp = Regexp.new('\A\s*((\'+[^\']+\'+)|(\"+[^\"]+\"+)|(\w[^,:(); \t\n]*|_)+)\s*') #  matches "foo and stuff", foo, 'stuff or foo', '''foo''', """bar""" BUT NOT ""foo" " # choking on 'Foo_stuff_things'
+  class LabelBase < Token
     def initialize(str)
       str.strip!
       str = str[1..-2] if str[0..0] == "'" # get rid of quote marks
       str = str[1..-2] if str[0..0] == '"'
       str.strip!
       @value = str
+    end
+  end
+
+  class Label < LabelBase
+    @regexp = Regexp.new(/\A\s*(#{QUOTEDLABEL}|(\w[^,:(); \t\n]*)+)\s*/) #  matches "foo and stuff", foo, 'stuff or foo', '''foo''', """bar""" BUT NOT ""foo" "
+    def initialize(str)
+      super(str)
+    end
+  end
+
+  class CharacterLabel < LabelBase
+    @regexp = Regexp.new(/\A\s*(#{QUOTEDLABEL}|[^ \t\n\/\'\",;]+)\s*/)
+    def initialize(str)
+      super(str)
     end
   end
 

--- a/test/test_nexus_parser.rb
+++ b/test/test_nexus_parser.rb
@@ -35,18 +35,18 @@ class Test_Lexer < Test::Unit::TestCase
   def test_lexer
     lexer = NexusParser::Lexer.new("[ foo ] BEGIN taxa; BLORF end;")
     assert lexer.pop(NexusParser::Tokens::LBracket)
-    assert id = lexer.pop(NexusParser::Tokens::ID)
+    assert id = lexer.pop(NexusParser::Tokens::Label)
     assert_equal(id.value, "foo")
     assert lexer.pop(NexusParser::Tokens::RBracket)
     assert lexer.pop(NexusParser::Tokens::BeginBlk)
     assert lexer.pop(NexusParser::Tokens::TaxaBlk)
-    assert foo = lexer.pop(NexusParser::Tokens::ID)
+    assert foo = lexer.pop(NexusParser::Tokens::Label)
     assert_equal("BLORF", foo.value) # truncating whitespace
     assert lexer.pop(NexusParser::Tokens::BlkEnd)
 
     lexer2 = NexusParser::Lexer.new("[ foo ] begin authors; BLORF end; [] ()  some crud here")
     assert lexer2.pop(NexusParser::Tokens::LBracket)
-    assert id = lexer2.pop(NexusParser::Tokens::ID)
+    assert id = lexer2.pop(NexusParser::Tokens::Label)
     assert_equal(id.value, "foo")
     assert lexer2.pop(NexusParser::Tokens::RBracket)
     assert lexer2.pop(NexusParser::Tokens::BeginBlk)
@@ -64,12 +64,12 @@ class Test_Lexer < Test::Unit::TestCase
 
     lexer3 = NexusParser::Lexer.new("[ foo ] Begin Characters; BLORF end; [] ()  some crud here")
     assert lexer3.pop(NexusParser::Tokens::LBracket)
-    assert id = lexer3.pop(NexusParser::Tokens::ID)
+    assert id = lexer3.pop(NexusParser::Tokens::Label)
     assert_equal(id.value, "foo")
     assert lexer3.pop(NexusParser::Tokens::RBracket)
     assert lexer3.pop(NexusParser::Tokens::BeginBlk)
     assert lexer3.pop(NexusParser::Tokens::ChrsBlk)
-    assert foo = lexer3.pop(NexusParser::Tokens::ID)
+    assert foo = lexer3.pop(NexusParser::Tokens::Label)
     assert_equal("BLORF", foo.value)
     assert lexer3.pop(NexusParser::Tokens::BlkEnd)
 
@@ -465,7 +465,7 @@ class Test_Lexer < Test::Unit::TestCase
 
   def test_lexer_errors
     lexer = NexusParser::Lexer.new("*&")
-    assert_raise(NexusParser::ParseError) {lexer.peek(NexusParser::Tokens::ID)}
+    assert_raise(NexusParser::ParseError) {lexer.peek(NexusParser::Tokens::Label)}
   end
 end
 

--- a/test/test_nexus_parser.rb
+++ b/test/test_nexus_parser.rb
@@ -462,11 +462,6 @@ class Test_Lexer < Test::Unit::TestCase
     assert_equal 'SETS', foo.value.slice(0,4)
     assert_equal 'END;', foo.value.slice(-4,4)
   end
-
-  def test_lexer_errors
-    lexer = NexusParser::Lexer.new("*&")
-    assert_raise(NexusParser::ParseError) {lexer.peek(NexusParser::Tokens::Label)}
-  end
 end
 
 

--- a/test/test_nexus_parser.rb
+++ b/test/test_nexus_parser.rb
@@ -76,17 +76,17 @@ class Test_Lexer < Test::Unit::TestCase
     lexer4 = NexusParser::Lexer.new("Begin Characters; 123123123 end; [] ()  some crud here")
     assert lexer4.pop(NexusParser::Tokens::BeginBlk)
     assert lexer4.pop(NexusParser::Tokens::ChrsBlk)
-    assert foo = lexer4.pop(NexusParser::Tokens::Number)
-    assert_equal(123123123, foo.value)
+    assert foo = lexer4.pop(NexusParser::Tokens::PositiveInteger)
+    assert_equal('123123123', foo.value)
     assert lexer4.pop(NexusParser::Tokens::BlkEnd)
 
     lexer5 = NexusParser::Lexer.new("(0,1)")
     assert lexer5.pop(NexusParser::Tokens::LParen)
-    assert foo = lexer5.pop(NexusParser::Tokens::Number)
-    assert_equal(0, foo.value)
+    assert foo = lexer5.pop(NexusParser::Tokens::PositiveInteger)
+    assert_equal('0', foo.value)
     assert lexer5.pop(NexusParser::Tokens::Comma)
-    assert foo = lexer5.pop(NexusParser::Tokens::Number)
-    assert_equal(1, foo.value)
+    assert foo = lexer5.pop(NexusParser::Tokens::PositiveInteger)
+    assert_equal('1', foo.value)
     assert lexer5.pop(NexusParser::Tokens::RParen)
 
     lexer6 =  NexusParser::Lexer.new(" 210(0,1)10A1\n")
@@ -938,7 +938,7 @@ class Test_Parser < Test::Unit::TestCase
 
 
   def test_number_label_chr_state_labels
-    # Character state names that start with Numbers
+    # Character state names that start with numbers
     input = 'CHARSTATELABELS 1 Tibia_II /
       123abc
       -1.23abc

--- a/test/test_nexus_parser.rb
+++ b/test/test_nexus_parser.rb
@@ -726,6 +726,68 @@ class Test_Parser < Test::Unit::TestCase
     assert_equal '0 1 2 3 4 5 6 7 8 9 A', foo.vars[:symbols]
   end
 
+  # https://github.com/mjy/nexus_parser/issues/9
+  def test_three_both_numeric_and_label_state_names_in_a_row
+    input =" CHARSTATELABELS
+    1 'Metatarsal trichobothria (CodAra.29)' / 3 9 27 asdf;
+    Matrix
+    fooo 01 more stuff here that should not be hit"
+
+    builder = NexusParser::Builder.new
+    lexer = NexusParser::Lexer.new(input)
+
+    builder.stub_chr()
+
+    NexusParser::Parser.new(lexer, builder).parse_chr_state_labels
+
+    foo = builder.nexus_file
+
+    assert_equal "3", foo.characters[0].states['0'].name
+    assert_equal "9", foo.characters[0].states['1'].name
+    assert_equal "27", foo.characters[0].states['2'].name
+    assert_equal "asdf", foo.characters[0].states['3'].name
+  end
+
+  def test_non_label_character_name_character_labels
+    input = 'CHARSTATELABELS
+     1 (intentionally_blank) /,
+     2 /,
+     3 %_coverage /,
+     4 #_of_widgets /,
+     5 !endangered! /,
+     6 @the_front /,
+     7 =antennae,
+     8 `a_=_2` /,
+     9 -35_or-36 ,
+     10 27_or_less /,
+     11 fine_not_fine /,
+     12 3,
+      ;'
+
+    builder = NexusParser::Builder.new
+    lexer = NexusParser::Lexer.new(input)
+
+    (0..11).each{builder.stub_chr()}
+
+    NexusParser::Parser.new(lexer,builder).parse_chr_state_labels
+
+    foo = builder.nexus_file
+
+    assert_equal 12, foo.characters.size
+    assert_equal "(intentionally_blank)", foo.characters[0].name
+    assert_equal "Undefined", foo.characters[1].name
+    assert_equal "%_coverage", foo.characters[2].name
+    assert_equal "#_of_widgets", foo.characters[3].name
+    assert_equal "!endangered!", foo.characters[4].name
+    assert_equal "@the_front", foo.characters[5].name
+    assert_equal "=antennae", foo.characters[6].name # =3
+    assert_equal "`a_=_2`", foo.characters[7].name
+    assert_equal "-35_or-36", foo.characters[8].name
+    assert_equal "27_or_less", foo.characters[9].name
+    assert_equal "fine_not_fine", foo.characters[10].name
+    assert_equal "3", foo.characters[11].name
+  end
+
   def test_parse_chr_state_labels
     input =" CHARSTATELABELS
     1 Tibia_II /  norm modified, 2 TII_macrosetae /  '= TI' stronger, 3 Femoral_tuber /  abs pres 'm-setae', 5 Cymbium /  dorsal mesal lateral, 6 Paracymbium /  abs pres, 7 Globular_tegulum /  abs pres, 8  /  entire w_lobe, 9 Conductor_wraps_embolus, 10 Median_apophysis /  pres abs ;
@@ -807,26 +869,114 @@ class Test_Parser < Test::Unit::TestCase
 
   end
 
-  # https://github.com/mjy/nexus_parser/issues/9
-  def test_three_both_numeric_and_label_state_names_in_a_row
-    input =" CHARSTATELABELS
-    1 'Metatarsal trichobothria (CodAra.29)' / 3 9 27 asdf;
-    Matrix
-    fooo 01 more stuff here that should not be hit"
+  def test_non_label_character_state_character_labels
+    input = 'CHARSTATELABELS 1 Tibia_II /
+      .5
+      .1.2_form
+      idsimple
+      %_of_length_less_than_10
+      !poisonous!
+      #_is_3_or_4
+      (leave_as_is)
+      @12_o_clock
+      >2
+      ~equal
+      =9
+      ;'
 
     builder = NexusParser::Builder.new
     lexer = NexusParser::Lexer.new(input)
 
     builder.stub_chr()
 
-    NexusParser::Parser.new(lexer, builder).parse_chr_state_labels
+    NexusParser::Parser.new(lexer,builder).parse_chr_state_labels
 
     foo = builder.nexus_file
 
-    assert_equal "3", foo.characters[0].states['0'].name
-    assert_equal "9", foo.characters[0].states['1'].name
-    assert_equal "27", foo.characters[0].states['2'].name
-    assert_equal "asdf", foo.characters[0].states['3'].name
+    assert_equal ".5", foo.characters[0].states["0"].name
+    assert_equal ".1.2_form", foo.characters[0].states["1"].name
+    assert_equal "idsimple", foo.characters[0].states["2"].name
+    assert_equal "%_of_length_less_than_10", foo.characters[0].states["3"].name
+    assert_equal "!poisonous!", foo.characters[0].states["4"].name
+    assert_equal "#_is_3_or_4", foo.characters[0].states["5"].name
+    assert_equal "(leave_as_is)", foo.characters[0].states["6"].name
+    assert_equal "@12_o_clock", foo.characters[0].states["7"].name
+    assert_equal ">2", foo.characters[0].states["8"].name
+    assert_equal "~equal", foo.characters[0].states["9"].name
+    assert_equal "=9", foo.characters[0].states["10"].name
+  end
+
+  def test_arbitrary_quote_and_quotelike_character_state_labels
+    # We could tighten up our handling of accidentally unclosed quotes, but
+    # there's pretty much no way to recover in general, so we're not testing
+    # them here.
+    # Things like ""asdf" " failing is a known issue (maybe not solvable with
+    # regular expressions?).
+    input = 'CHARSTATELABELS 1 Tibia_II /
+      "asd, \'f\'"
+      ""a\'sdf  "
+      \'  /as"df/\'
+      \'asdf;\'
+      ""as, df""
+      ;'
+
+    builder = NexusParser::Builder.new
+    lexer = NexusParser::Lexer.new(input)
+
+    builder.stub_chr()
+
+    NexusParser::Parser.new(lexer,builder).parse_chr_state_labels
+
+    foo = builder.nexus_file
+
+    assert_equal 'asd, \'f\'', foo.characters[0].states["0"].name
+    assert_equal '"a\'sdf', foo.characters[0].states["1"].name
+    assert_equal '/as"df/', foo.characters[0].states["2"].name
+    assert_equal 'asdf;', foo.characters[0].states["3"].name
+    assert_equal '"as, df"', foo.characters[0].states["4"].name
+  end
+
+
+  def test_number_label_chr_state_labels
+    # Character state names that start with Numbers
+    input = 'CHARSTATELABELS 1 Tibia_II /
+      123abc
+      -1.23abc
+      -3e-3abc
+      25%_or_less_than
+      ;'
+
+    builder = NexusParser::Builder.new
+    lexer = NexusParser::Lexer.new(input)
+
+    (0..3).each{builder.stub_chr()}
+
+    NexusParser::Parser.new(lexer,builder).parse_chr_state_labels
+
+    foo = builder.nexus_file
+
+    assert_equal "123abc", foo.characters[0].states["0"].name
+    assert_equal "-1.23abc", foo.characters[0].states["1"].name
+    assert_equal "-3e-3abc", foo.characters[0].states["2"].name
+    assert_equal "25%_or_less_than", foo.characters[0].states["3"].name
+  end
+
+  def test_value_pair_label_chr_state_labels
+    # Character state names that are ValuePairs
+    input = 'CHARSTATELABELS 1 Tibia_II /
+      234=(a_b_c)
+      ;'
+
+    builder = NexusParser::Builder.new
+    lexer = NexusParser::Lexer.new(input)
+
+    builder.stub_chr()
+
+    NexusParser::Parser.new(lexer,builder).parse_chr_state_labels
+
+    foo = builder.nexus_file
+
+    assert_equal '234=(a_b_c)', foo.characters[0].states["0"].name
   end
 
   def DONT_test_parse_really_long_string_of_chr_state_labels


### PR DESCRIPTION
I'll pull from the commit messages here to summarize - this is a somewhat big change, so please feel free to object (not that I needed to say that).

These commits try to solve two issues.

1) The main issue this fixes is overlap of Tokens when combined with Lexer's peek caching of tokens other than the one it was told to peek on.

The specific issue here was trying to tokenize character state names. Say we're trying to parse `123asdf` as a character state name. Our first step is to peek on the lexer for a semicolon to see if we're already at the end. In this case that fails but the peek stores `Tokens::Number: 123` on the lexer as the next token (Number is tried before Label is). Now we want to allow Numbers or Labels as char state name tokens (they're different classes), so we either have to peek for a Number or a Label at this point.

If we peek for a Number we get `123` but now what's left of the name is `asdf` and the lexer doesn't expose if it was originally the string `123 abc` - in which case we should parse two separate tokens - or if it was really `123abc` in which case we could read a Label again to get the whole name. No way to know without exposing more information from the lexer.

If we instead peek for a Label first then we fail because what's on the lexer already is a Number token, not a Label token. At that point we're out of luck.

It's even worse though: what if my character state name was `a=b`? Then peeking for a semicolon puts a ValuePair on the lexer and now peeking for neither Number nor Label will find anything. Similarly with `ids...` as both a MesquiteId and a Label, etc. etc. Many things overlap with Label.

The fix here is to no longer match any token except the type of the one that was peeked on. At this point one might object that now we'll never know when we're trying to peek an unrecognized token, but I think that was actually always the case.

Note that RowVec matches *every* non-nil input (since every token slurps whitespace).

That means that we were *never* erroring out on peek matching no token - we were erroring out because instead of any of the tokens we thought we might see in a particular block, we wound up matching something like RowVec we didn't expect to see and then wound up in an infinite loop because none of our peeks worked anymore because a RowVec was on the lexer when nobody was peeking for a RowVec (these are the "gazillion ..." errors).

Removing the 'no token recognized' error just accepts that fact in a different way: we still error out on the gazillion/infinite loop - still because we're not seeing any of the tokens we expected to see - but now we're just storing nothing on the lexer when we don't find a match instead of storing something broad like RowVec that was bogus anyway.

If you *want* to match RowVec you need to peek for it or just pop and pray.

2) We currently try to accept character state names that are Numbers or Labels. If the name is quoted then it's a Label and that's the end of the story, so consider non-quoted Labels, which have to start with `\w`. `\w` contains digits, so any positive Number is a Label. But so are things like `123abc`. `\w` does not contain `-`, so no negative Numbers are Labels, and something like `-123abc` would cause an error because it's neither a Number nor a Label.

The fix here was to write a new CharacterLabel that's meant to match any Character name and any CharacterState name: it's any quoted thing as in Label, or `[^ \t\n\/\'\",;]+`. That more closely matches Mesquite and TW, which I think both allow you to enter pretty arbitrary strings here (though they may get quoted on export, and Mesquite for example doesn't allow pure numbers like `1234`). Also note that any un-quoted token we match with CharacterLabel is indistinguishable from the same string surrounded by quotes being parsed, since we remove quotes on import, and that any of the strings matched by CharacterLabel are legal inside quotes (so we can quote them on export and then roundtrip them back in on import).
