### PR TITLE
Raise NexusParser::ParseError when there are more taxon names than ntax

### DIFF
--- a/lib/nexus_parser.rb
+++ b/lib/nexus_parser.rb
@@ -171,6 +171,9 @@ class Builder
       :name => ''
     }.merge!(options)
     return false if !@opt[:index]
+
+    raise(ParseError, "Trying to assign a name to taxon #{@opt[:index] + 1}, but there are only #{@nf.taxa.size} taxa - do some taxon names have internal (not at the ends) quotes?") if @nf.taxa[@opt[:index]].nil?
+
     (@nf.taxa[@opt[:index]].name = @opt[:name]) if @opt[:name]
   end
 


### PR DESCRIPTION
This can happen in the obvious way (listing more taxa than ntax) but also with a taxon like '''Foo'' fud' which gets parsed into two names (or something) in a way that's currently difficult (for me) to fix.

This provides a more informative error message in TW.